### PR TITLE
Fix typo and booking auth listener

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -127,8 +127,8 @@ A page that allows members to book the ACM lounge for a period of time, and also
 
 **Existing Functionality:**
 
-- Availible and unavaile times with dates/times
-- Limit of registration time/occurences
+- Available and unavailable times with dates/times
+- Limit of registration time/occurrences
 
 **Possible Components:**
 

--- a/acm_website/src/App.css
+++ b/acm_website/src/App.css
@@ -111,7 +111,7 @@
   left: 0;
   width: 100%;
   height: 100%;
-  background-color: rgba(0, 45, 114, 0.8); /* #002D72 with 20% opacity */
+  background-color: rgba(0, 45, 114, 0.8); /* #002D72 with 80% opacity */
   z-index: 1;
 }
 

--- a/acm_website/src/pages/BookingPage.tsx
+++ b/acm_website/src/pages/BookingPage.tsx
@@ -46,13 +46,16 @@ const BookingPage: React.FC<BookingPageProps> = ({ navigateTo, error }) => {
   const [bookingSuccess, setBookingSuccess] = useState<string>('');
 
   // Initial auth check
-  onAuthStateChanged(auth, (user) => {
-    if (user) {
-      // User is signed in
-    } else {
-      navigateTo('login', 'Please log in to access the booking page');
-    }
-  });
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        // User is signed in
+      } else {
+        navigateTo('login', 'Please log in to access the booking page');
+      }
+    });
+    return unsubscribe;
+  }, []);
 
   // Generate time slots for dropdowns
   useEffect(() => {


### PR DESCRIPTION
## Summary
- fix grammar in CONTRIBUTING docs
- wrap BookingPage auth listener in useEffect
- correct overlay opacity comment

## Testing
- `npm test` *(fails: Missing script)*
- `npm --prefix acm_backend test` *(fails: Error: no test specified)*