### PR TITLE
Implement backend delete user API and integrate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 node_modules/*
+.env

--- a/acm_backend/package.json
+++ b/acm_backend/package.json
@@ -4,6 +4,8 @@
   "description": "",
   "main": "index.js",
   "scripts": {
+    "start": "node server.js",
+    "dev": "nodemon server.js",
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],

--- a/acm_backend/server.js
+++ b/acm_backend/server.js
@@ -1,0 +1,43 @@
+// Backend server setup
+
+const express = require('express');
+const cors = require('cors');
+const admin = require('firebase-admin');
+require('dotenv').config();
+
+const app = express();
+app.use(cors());
+app.use(express.json());
+
+// Initialize Firebase Admin SDK if not already initialized
+if (!admin.apps.length) {
+  admin.initializeApp({
+    credential: admin.credential.cert({
+      projectId: process.env.FIREBASE_PROJECT_ID,
+      clientEmail: process.env.FIREBASE_CLIENT_EMAIL,
+      privateKey: process.env.FIREBASE_PRIVATE_KEY?.replace(/\\n/g, '\n'),
+    }),
+  });
+}
+
+// Delete a user by UID
+app.post('/deleteUser', async (req, res) => {
+  const { uid } = req.body;
+  if (!uid) {
+    return res.status(400).json({ message: 'UID is required' });
+  }
+
+  try {
+    await admin.auth().deleteUser(uid);
+    return res.status(200).json({ message: 'User deleted successfully' });
+  } catch (error) {
+    console.error('Error deleting user:', error);
+    return res.status(500).json({ message: 'Error deleting user' });
+  }
+});
+
+const PORT = process.env.PORT || 3001;
+app.listen(PORT, () => {
+  console.log(`Server running on port ${PORT}`);
+});
+

--- a/acm_website/src/api.ts
+++ b/acm_website/src/api.ts
@@ -1,0 +1,16 @@
+const API_BASE_URL = import.meta.env.VITE_API_BASE_URL || 'http://localhost:3001';
+
+export async function deleteUser(uid: string): Promise<void> {
+  const response = await fetch(`${API_BASE_URL}/deleteUser`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json'
+    },
+    body: JSON.stringify({ uid })
+  });
+
+  if (!response.ok) {
+    throw new Error('Failed to delete user');
+  }
+}
+

--- a/acm_website/src/pages/AdminPage.tsx
+++ b/acm_website/src/pages/AdminPage.tsx
@@ -3,6 +3,7 @@ import './LoginPage.css';
 import { auth } from '../firebase/config';
 import { onAuthStateChanged, signOut } from "firebase/auth";
 import { collection, doc, getFirestore, getDocs, query, where, updateDoc, addDoc, Timestamp, orderBy } from "firebase/firestore";
+import { deleteUser } from '../api';
 
 interface AdminPageProps {
   navigateTo: (page: string, errorMessage?: string) => void;
@@ -132,6 +133,9 @@ const AdminPage: React.FC<AdminPageProps> = ({ navigateTo, error }) => {
         await updateDoc(doc(db, "users", uid), {
           isMember: false
         });
+
+        await deleteUser(uid);
+
         setMembers(prev => prev.filter(member => member.uid !== uid));
       } catch (error) {
         console.error('Error removing member:', error);

--- a/acm_website/src/pages/AdminPage.tsx
+++ b/acm_website/src/pages/AdminPage.tsx
@@ -131,7 +131,9 @@ const AdminPage: React.FC<AdminPageProps> = ({ navigateTo, error }) => {
       try {
         const db = getFirestore();
         await updateDoc(doc(db, "users", uid), {
-          isMember: false
+          isMember: false,
+          deleted: true,
+          deletedAt: Timestamp.now()
         });
 
         await deleteUser(uid);


### PR DESCRIPTION
## Summary
- set up Express backend server
- add `/deleteUser` endpoint using Firebase Admin
- expose API functions for frontend
- call the delete API in admin member removal

## Testing
- `npm test` *(fails: Error: no test specified)*
- `npm run lint` in `acm_website` *(fails due to existing lint errors)*