### PR TITLE
Refactor page styles into CSS

### DIFF
--- a/acm_website/src/App.tsx
+++ b/acm_website/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState } from 'react';
 import './App.css';
+import './styles/Common.css';
 import HomePage from './pages/HomePage';
 import AboutPage from './pages/AboutPage';
 import EventsPage from './pages/EventsPage';

--- a/acm_website/src/pages/AboutPage.tsx
+++ b/acm_website/src/pages/AboutPage.tsx
@@ -5,6 +5,7 @@ import juliaImage from '../assets/alumni/julia bian.jpeg';
 import nishImage from '../assets/alumni/nish.jpeg';
 import chaseImage from '../assets/alumni/chase feng.jpeg';
 import '../styles/FlipCard.css';
+import '../styles/AboutPage.css';
 
 interface AboutPageProps {
   navigateTo: (page: string, errorMessage?: string) => void;
@@ -149,38 +150,31 @@ const AboutPage: React.FC<AboutPageProps> = ({ navigateTo, error }) => {
   ];
 
   return (
-    <div className="about-container" style={{ position: 'relative', zIndex: 1 }}>
+    <div className="about-container relative-z-1">
       {error && (
             <div className="error-message">
               {error}
             </div>
           )}
-      <div className="about-background" style={{ zIndex: -1 }}></div>
-      <h1 className="about-title" style={{ position: 'relative', zIndex: 2, color: 'white' }}>About Us</h1>
+      <div className="about-background about-background-low"></div>
+      <h1 className="about-title relative-z-2 text-white">About Us</h1>
       
-      <div className="about-content" style={{ position: 'relative', zIndex: 2 }}>
-        <p style={{ color: 'white' }}>
+      <div className="about-content relative-z-2">
+        <p className="text-white">
           We are a student organization of the Johns Hopkins University dedicated to furthering the knowledge and advancement of computers and 
           information technology through the free exchange of ideas and information. As a chapter of the oldest computing society in the world, the JHU ACM 
           is a place for diverse backgrounds and interests, and serves the JHU community as a whole. During the semester, the ACM has weekly meetings in 
-          Malone announced via email and posted on our <a href="#" className="link" style={{ color: 'white', textDecoration: 'underline' }}>Facebook</a> page and the <a href="#" className="link" style={{ color: 'white', textDecoration: 'underline' }}>Events</a> section of this website.
+          Malone announced via email and posted on our <a href="#" className="link text-white underline">Facebook</a> page and the <a href="#" className="link text-white underline">Events</a> section of this website.
         </p>
       </div>
       
-      <h2 className="leadership-title" style={{ position: 'relative', zIndex: 2, color: 'white' }}>Officers</h2>
-      
-      <div style={{ 
-        display: 'grid', 
-        gridTemplateColumns: 'repeat(4, 1fr)', 
-        gap: '20px', 
-        margin: '30px 0' 
-      }}>
+      <h2 className="leadership-title relative-z-2 text-white">Officers</h2>
+      <div className="card-grid">
         {leadershipData.map((leader, index) => (
-          <div 
-            key={index} 
-            className={`flip-card ${flippedCards.includes(index) ? 'flipped' : ''}`}
+          <div
+            key={index}
+            className={`flip-card ${flippedCards.includes(index) ? 'flipped' : ''} cursor-pointer`}
             onClick={() => toggleFlip(index)}
-            style={{ cursor: 'pointer' }}
           >
             <div className="flip-card-inner">
               <div className="flip-card-front">
@@ -192,24 +186,16 @@ const AboutPage: React.FC<AboutPageProps> = ({ navigateTo, error }) => {
                   }}
                 />
               </div>
-              <div className="flip-card-back" style={{ color: 'white' }}>
-                <h3 style={{ margin: '0 0 5px 0', fontSize: '1rem', color: 'white' }}>{leader.name}</h3>
-                <h4 style={{ margin: '0 0 5px 0', fontWeight: 'normal', fontSize: '0.9rem', color: 'white' }}>{leader.role}</h4>
-                <p style={{ fontSize: '0.8rem', margin: '0 0 8px 0', color: 'white' }}>{leader.bio}</p>
-                <a 
-                  href={leader.linkedin} 
-                  target="_blank" 
+              <div className="flip-card-back">
+                <h3 className="m-0 mb-[5px] text-[1rem] text-white">{leader.name}</h3>
+                <h4 className="m-0 mb-[5px] font-normal text-[0.9rem] text-white">{leader.role}</h4>
+                <p className="text-[0.8rem] m-0 mb-2 text-white">{leader.bio}</p>
+                <a
+                  href={leader.linkedin}
+                  target="_blank"
                   rel="noopener noreferrer"
                   onClick={(e) => e.stopPropagation()}
-                  style={{
-                    color: '#0077b5',
-                    textDecoration: 'none',
-                    fontSize: '0.8rem',
-                    backgroundColor: 'white',
-                    padding: '2px 8px',
-                    borderRadius: '4px',
-                    display: 'inline-block'
-                  }}
+                  className="linkedin-link"
                 >
                   LinkedIn
                 </a>
@@ -219,20 +205,13 @@ const AboutPage: React.FC<AboutPageProps> = ({ navigateTo, error }) => {
         ))}
       </div>
       
-      <h2 className="alumni-title" style={{ color: 'white', marginTop: '40px' }}>Alumni</h2>
-      
-      <div style={{ 
-        display: 'grid', 
-        gridTemplateColumns: 'repeat(4, 1fr)', 
-        gap: '20px', 
-        margin: '30px 0' 
-      }}>
+      <h2 className="alumni-title text-white mt-[40px]">Alumni</h2>
+      <div className="card-grid">
         {alumniData.map((alumni, index) => (
-          <div 
-            key={index} 
-            className={`flip-card ${flippedAlumniCards.includes(index) ? 'flipped' : ''}`}
+          <div
+            key={index}
+            className={`flip-card ${flippedAlumniCards.includes(index) ? 'flipped' : ''} cursor-pointer`}
             onClick={() => toggleAlumniFlip(index)}
-            style={{ cursor: 'pointer' }}
           >
             <div className="flip-card-inner">
               <div className="flip-card-front">
@@ -244,24 +223,16 @@ const AboutPage: React.FC<AboutPageProps> = ({ navigateTo, error }) => {
                   }}
                 />
               </div>
-              <div className="flip-card-back" style={{ color: 'white' }}>
-                <h3 style={{ margin: '0 0 5px 0', fontSize: '1rem', color: 'white' }}>{alumni.name}</h3>
-                <h4 style={{ margin: '0 0 5px 0', fontWeight: 'normal', fontSize: '0.9rem', color: 'white' }}>{alumni.role}</h4>
-                <p style={{ fontSize: '0.8rem', margin: '0 0 8px 0', color: 'white' }}>{alumni.bio}</p>
-                <a 
-                  href={alumni.linkedin} 
-                  target="_blank" 
+              <div className="flip-card-back">
+                <h3 className="m-0 mb-[5px] text-[1rem] text-white">{alumni.name}</h3>
+                <h4 className="m-0 mb-[5px] font-normal text-[0.9rem] text-white">{alumni.role}</h4>
+                <p className="text-[0.8rem] m-0 mb-2 text-white">{alumni.bio}</p>
+                <a
+                  href={alumni.linkedin}
+                  target="_blank"
                   rel="noopener noreferrer"
                   onClick={(e) => e.stopPropagation()}
-                  style={{
-                    color: '#0077b5',
-                    textDecoration: 'none',
-                    fontSize: '0.8rem',
-                    backgroundColor: 'white',
-                    padding: '2px 8px',
-                    borderRadius: '4px',
-                    display: 'inline-block'
-                  }}
+                  className="linkedin-link"
                 >
                   LinkedIn
                 </a>
@@ -273,22 +244,9 @@ const AboutPage: React.FC<AboutPageProps> = ({ navigateTo, error }) => {
       
       <button className="home-button" onClick={() => navigateTo('home')}>Back to Home</button>
       
-      <div 
+      <div
         onClick={() => navigateTo('credits')}
-        style={{ 
-          fontSize: '0.8rem', 
-          textAlign: 'center', 
-          position: 'fixed',
-          bottom: '0',
-          left: '0',
-          right: '0',
-          color: 'white',
-          opacity: 0.8,
-          cursor: 'pointer',
-          backgroundColor: 'rgba(50, 50, 50, 0.5)',
-          padding: '8px 0',
-          backdropFilter: 'blur(2px)'
-        }}
+        className="credits-footer"
       >
         made with lots of ❤️ @JHU ACM
       </div>

--- a/acm_website/src/pages/AdminPage.tsx
+++ b/acm_website/src/pages/AdminPage.tsx
@@ -278,7 +278,7 @@ const AdminPage: React.FC<AdminPageProps> = ({ navigateTo, error }) => {
 
   return (
     <div className="login-page">
-      <div className="about-background" style={{ zIndex: -1 }}></div>
+      <div className="about-background about-background-low"></div>
       <div className="login-container">
         {error && (
           <div className="error-message">

--- a/acm_website/src/pages/CreditsPage.tsx
+++ b/acm_website/src/pages/CreditsPage.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from 'react';
 import placeholderImage from '../assets/depositphotos_104564156-stock-illustration-male-user-icon.jpg';
 import '../styles/FlipCard.css';
+import '../styles/CreditsPage.css';
 
 interface CreditsPageProps {
   navigateTo: (page: string, errorMessage?: string) => void;
@@ -61,38 +62,32 @@ const CreditsPage: React.FC<CreditsPageProps> = ({ navigateTo, error }) => {
   ];
 
   return (
-    <div className="about-container" style={{ position: 'relative', zIndex: 1 }}>
-      <div className="about-background" style={{ zIndex: -1 }}></div>
+    <div className="about-container relative-z-1">
+      <div className="about-background about-background-low"></div>
       {error && (
-        <div className="error-message" style={{ position: 'relative', zIndex: 2 }}>
+        <div className="error-message relative-z-2">
           {error}
         </div>
       )}
-      <h1 className="about-title" style={{ color: 'white', position: 'relative', zIndex: 2 }}>Credits</h1>
-      
-      <div className="about-content" style={{ position: 'relative', zIndex: 2 }}>
-        <div style={{ marginBottom: '30px' }}>
-          <h2 style={{ color: 'white', marginBottom: '10px' }}>Website Development</h2>
-          <ul style={{ listStyleType: 'none', color: 'white' }}>
+      <h1 className="about-title text-white relative-z-2">Credits</h1>
+
+      <div className="about-content relative-z-2">
+        <div className="mb-[30px]">
+          <h2 className="text-white mb-[10px]">Website Development</h2>
+          <ul className="list-none text-white">
             <li>Brought to you by: Spring 2025 JHU ACM Coding Circle</li>
             <li>Framework: React with TypeScript</li>
           </ul>
         </div>
-        
-        <h2 style={{ color: 'white', marginBottom: '20px' }}>Contributors</h2>
-        
-        <div style={{ 
-          display: 'grid', 
-          gridTemplateColumns: 'repeat(4, 1fr)', 
-          gap: '20px', 
-          margin: '30px 0' 
-        }}>
+
+        <h2 className="text-white mb-[20px]">Contributors</h2>
+
+        <div className="contributors-grid">
           {contributorsData.map((contributor, index) => (
-            <div 
-              key={index} 
-              className={`flip-card ${flippedCards.includes(index) ? 'flipped' : ''}`}
+            <div
+              key={index}
+              className={`flip-card ${flippedCards.includes(index) ? 'flipped' : ''} cursor-pointer`}
               onClick={() => toggleFlip(index)}
-              style={{ cursor: 'pointer' }}
             >
               <div className="flip-card-inner">
                 <div className="flip-card-front">
@@ -105,23 +100,15 @@ const CreditsPage: React.FC<CreditsPageProps> = ({ navigateTo, error }) => {
                   />
                 </div>
                 <div className="flip-card-back">
-                  <h3 style={{ margin: '0 0 5px 0', fontSize: '1rem' }}>{contributor.name}</h3>
-                  <h4 style={{ margin: '0 0 5px 0', fontWeight: 'normal', fontSize: '0.9rem' }}>{contributor.role}</h4>
-                  <p style={{ fontSize: '0.8rem', margin: '0 0 8px 0', color: 'inherit' }}>{contributor.bio}</p>
-                  <a 
-                    href={contributor.linkedin} 
-                    target="_blank" 
+                  <h3 className="m-0 mb-[5px] text-[1rem]">{contributor.name}</h3>
+                  <h4 className="m-0 mb-[5px] font-normal text-[0.9rem]">{contributor.role}</h4>
+                  <p className="text-[0.8rem] m-0 mb-2">{contributor.bio}</p>
+                  <a
+                    href={contributor.linkedin}
+                    target="_blank"
                     rel="noopener noreferrer"
                     onClick={(e) => e.stopPropagation()}
-                    style={{
-                      color: '#0077b5',
-                      textDecoration: 'none',
-                      fontSize: '0.8rem',
-                      backgroundColor: 'white',
-                      padding: '2px 8px',
-                      borderRadius: '4px',
-                      display: 'inline-block'
-                    }}
+                    className="linkedin-link"
                   >
                     LinkedIn
                   </a>
@@ -130,58 +117,33 @@ const CreditsPage: React.FC<CreditsPageProps> = ({ navigateTo, error }) => {
             </div>
           ))}
         </div>
-        
-        <div style={{ marginBottom: '30px', marginTop: '30px' }}>
-          <h2 style={{ color: 'white', marginBottom: '10px' }}>Special Thanks</h2>
-          <ul style={{ listStyleType: 'none', color: 'white' }}>
+
+        <div className="my-[30px]">
+          <h2 className="text-white mb-[10px]">Special Thanks</h2>
+          <ul className="list-none text-white">
             <li>JHU Computer Science Department</li>
             <li>ACM National Organization</li>
             <li>All our dedicated members</li>
           </ul>
         </div>
-        
-        <div style={{ marginBottom: '30px' }}>
-          <h2 style={{ color: 'white', marginBottom: '10px' }}>Contact</h2>
-          <p style={{ color: 'white' }}>For questions or feedback about this website, please contact:</p>
-          <p><a href="mailto:acm@jhu.edu" style={{ color: 'white', textDecoration: 'underline' }}>acm@jhu.edu</a></p>
+
+        <div className="mb-[30px]">
+          <h2 className="text-white mb-[10px]">Contact</h2>
+          <p className="text-white">For questions or feedback about this website, please contact:</p>
+          <p><a href="mailto:acm@jhu.edu" className="text-white underline">acm@jhu.edu</a></p>
         </div>
       </div>
       
-      <button 
-        className="home-button" 
+      <button
+        className="home-button credits-home-button"
         onClick={() => navigateTo('home')}
-        style={{ 
-          padding: '8px 16px',
-          backgroundColor: '#3366cc',
-          color: 'white',
-          border: 'none',
-          borderRadius: '4px',
-          cursor: 'pointer',
-          marginTop: '20px',
-          position: 'relative',
-          zIndex: 2
-        }}
       >
         Back to Home
       </button>
       
-      <div 
+      <div
         onClick={() => navigateTo('credits')}
-        style={{ 
-          fontSize: '0.8rem', 
-          textAlign: 'center', 
-          position: 'fixed',
-          bottom: '0',
-          left: '0',
-          right: '0',
-          color: 'white',
-          opacity: 0.8,
-          cursor: 'pointer',
-          backgroundColor: 'rgba(50, 50, 50, 0.5)',
-          padding: '8px 0',
-          backdropFilter: 'blur(2px)',
-          zIndex: 2
-        }}
+        className="credits-footer"
       >
         made with lots of ❤️ @JHU ACM
       </div>

--- a/acm_website/src/pages/EventsPage.tsx
+++ b/acm_website/src/pages/EventsPage.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import '../styles/EventsPage.css';
 
 interface EventsPageProps {
   navigateTo: (page: string, errorMessage?: string) => void;
@@ -35,17 +36,17 @@ const EventsPage: React.FC<EventsPageProps> = ({ navigateTo, error }) => {
   ];
 
   return (
-    <div className="events-container" style={{ position: 'relative', zIndex: 1 }}>
-      <div className="about-background" style={{ zIndex: -1 }}></div>
+    <div className="events-container relative-z-1">
+      <div className="about-background about-background-low"></div>
       {error && (
-        <div className="error-message" style={{ position: 'relative', zIndex: 2 }}>
+        <div className="error-message relative-z-2">
           {error}
         </div>
       )}
-      <h1 className="events-title" style={{ position: 'relative', zIndex: 2 }}>Upcoming Events</h1>
-      <div className="events-list" style={{ position: 'relative', zIndex: 2 }}>
+      <h1 className="events-title relative-z-2">Upcoming Events</h1>
+      <div className="events-list relative-z-2">
         {events.map(event => (
-          <div key={event.id} className="event-card" style={{ position: 'relative', zIndex: 2 }}>
+          <div key={event.id} className="event-card relative-z-2">
             <h2 className="event-title">{event.title}</h2>
             <div className="event-details">
               <p><strong>Date:</strong> {event.date}</p>
@@ -57,25 +58,11 @@ const EventsPage: React.FC<EventsPageProps> = ({ navigateTo, error }) => {
           </div>
         ))}
       </div>
-      <button className="home-button" onClick={() => navigateTo('home')} style={{ position: 'relative', zIndex: 2 }}>Back to Home</button>
+      <button className="home-button relative-z-2" onClick={() => navigateTo('home')}>Back to Home</button>
       
-      <div 
+      <div
         onClick={() => navigateTo('credits')}
-        style={{ 
-          fontSize: '0.8rem', 
-          textAlign: 'center', 
-          position: 'fixed',
-          bottom: '0',
-          left: '0',
-          right: '0',
-          color: 'white',
-          opacity: 0.8,
-          cursor: 'pointer',
-          backgroundColor: 'rgba(50, 50, 50, 0.5)',
-          padding: '8px 0',
-          backdropFilter: 'blur(2px)',
-          zIndex: 2
-        }}
+        className="credits-footer"
       >
         Made with lots of ❤️ by JHU ACM
       </div>

--- a/acm_website/src/pages/HomePage.tsx
+++ b/acm_website/src/pages/HomePage.tsx
@@ -1,6 +1,7 @@
 import React, { useState, useEffect } from 'react';
 import { auth } from '../firebase/config';
 import { onAuthStateChanged } from "firebase/auth";
+import '../styles/HomePage.css';
 
 interface HomePageProps {
   navigateTo: (page: string, errorMessage?: string) => void;
@@ -19,18 +20,18 @@ const HomePage: React.FC<HomePageProps> = ({ navigateTo, error }) => {
   }, []);
 
   return (
-    <div className="flex flex-col items-center justify-center min-h-[70vh] p-8" style={{ position: 'relative', zIndex: 1 }}>
-      <div className="about-background" style={{ zIndex: -1 }}></div>
+    <div className="flex flex-col items-center justify-center min-h-[70vh] p-8 relative-z-1">
+      <div className="about-background about-background-low"></div>
       
       {error && (
-        <div className="error-message" style={{ position: 'relative', zIndex: 2 }}>
+        <div className="error-message relative-z-2">
           {error}
         </div>
       )}
       
-      <h1 className="text-4xl font-bold mb-4 text-gray-800" style={{ position: 'relative', zIndex: 2 }}>Welcome to JHU ACM</h1>
-      <p className="text-xl mb-8 text-gray-600" style={{ position: 'relative', zIndex: 2 }}>Association for Computing Machinery</p>
-      <div className="flex gap-4" style={{ position: 'relative', zIndex: 2 }}>
+      <h1 className="text-4xl font-bold mb-4 text-gray-800 relative-z-2">Welcome to JHU ACM</h1>
+      <p className="text-xl mb-8 text-gray-600 relative-z-2">Association for Computing Machinery</p>
+      <div className="flex gap-4 relative-z-2">
         <button 
           className="px-6 py-3 bg-indigo-600 text-white rounded-md hover:bg-indigo-700 transition-colors"
           onClick={() => navigateTo('about')}
@@ -57,23 +58,9 @@ const HomePage: React.FC<HomePageProps> = ({ navigateTo, error }) => {
         </button>
       </div>
       
-      <div 
+      <div
         onClick={() => navigateTo('credits')}
-        style={{ 
-          fontSize: '0.8rem', 
-          textAlign: 'center', 
-          position: 'fixed',
-          bottom: '0',
-          left: '0',
-          right: '0',
-          color: 'white',
-          opacity: 0.8,
-          cursor: 'pointer',
-          backgroundColor: 'rgba(50, 50, 50, 0.5)',
-          padding: '8px 0',
-          backdropFilter: 'blur(2px)',
-          zIndex: 2
-        }}
+        className="credits-footer"
       >
         Made with lots of ❤️ by JHU ACM
       </div>

--- a/acm_website/src/pages/LoginPage.tsx
+++ b/acm_website/src/pages/LoginPage.tsx
@@ -88,7 +88,7 @@ const LoginPage: React.FC<LoginPageProps> = ({ navigateTo, error }) => {
 
   return (
     <div className="login-page">
-      <div className="about-background" style={{ zIndex: -1 }}></div>
+      <div className="about-background about-background-low"></div>
       <div className="login-container">
         <div className="login-box">
           <form onSubmit={handleLogin}>

--- a/acm_website/src/styles/AboutPage.css
+++ b/acm_website/src/styles/AboutPage.css
@@ -1,0 +1,6 @@
+.card-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin: 30px 0;
+}

--- a/acm_website/src/styles/AdminPage.css
+++ b/acm_website/src/styles/AdminPage.css
@@ -40,29 +40,6 @@
   background-color: #002244;
 }
 
-.error-message {
-  color: red;
-  font-size: 0.875rem;
-  margin-bottom: 1rem;
-  width: 100%;
-  text-align: center;
-}
-
-.home-button {
-  display: block;
-  margin: 1rem auto;
-  padding: 0.5rem 1rem;
-  background-color: #003366;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: bold;
-}
-
-.home-button:hover {
-  background-color: #002244;
-}
 
 .home-fixed {
   position: fixed;

--- a/acm_website/src/styles/Common.css
+++ b/acm_website/src/styles/Common.css
@@ -1,0 +1,63 @@
+.error-message {
+  color: red;
+  font-size: 0.875rem;
+  margin-bottom: 1rem;
+  width: 100%;
+  text-align: center;
+}
+
+.home-button {
+  display: block;
+  margin: 1rem auto;
+  padding: 0.5rem 1rem;
+  background-color: #003366;
+  color: #fff;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  font-weight: bold;
+}
+
+.home-button:hover {
+  background-color: #002244;
+}
+
+.relative-z-1 {
+  position: relative;
+  z-index: 1;
+}
+
+.relative-z-2 {
+  position: relative;
+  z-index: 2;
+}
+
+.about-background-low {
+  z-index: -1;
+}
+
+.credits-footer {
+  font-size: 0.8rem;
+  text-align: center;
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  color: white;
+  opacity: 0.8;
+  cursor: pointer;
+  background-color: rgba(50, 50, 50, 0.5);
+  padding: 8px 0;
+  backdrop-filter: blur(2px);
+  z-index: 2;
+}
+
+.linkedin-link {
+  color: #0077b5;
+  text-decoration: none;
+  font-size: 0.8rem;
+  background-color: white;
+  padding: 2px 8px;
+  border-radius: 4px;
+  display: inline-block;
+}

--- a/acm_website/src/styles/CreditsPage.css
+++ b/acm_website/src/styles/CreditsPage.css
@@ -1,0 +1,18 @@
+.contributors-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 20px;
+  margin: 30px 0;
+}
+
+.credits-home-button {
+  padding: 8px 16px;
+  background-color: #3366cc;
+  color: white;
+  border: none;
+  border-radius: 4px;
+  cursor: pointer;
+  margin-top: 20px;
+  position: relative;
+  z-index: 2;
+}

--- a/acm_website/src/styles/EventsPage.css
+++ b/acm_website/src/styles/EventsPage.css
@@ -1,0 +1,1 @@
+/* EventsPage specific styles */

--- a/acm_website/src/styles/HomePage.css
+++ b/acm_website/src/styles/HomePage.css
@@ -1,0 +1,1 @@
+/* HomePage specific styles */

--- a/acm_website/src/styles/LoginPage.css
+++ b/acm_website/src/styles/LoginPage.css
@@ -88,29 +88,6 @@
   text-decoration: underline;
 }
 
-.error-message {
-  color: red;
-  font-size: 0.875rem;
-  margin-bottom: 1rem;
-  width: 100%;
-  text-align: center;
-}
-
-.home-button {
-  display: block;
-  margin: 1rem auto;
-  padding: 0.5rem 1rem;
-  background-color: #003366;
-  color: #fff;
-  border: none;
-  border-radius: 4px;
-  cursor: pointer;
-  font-weight: bold;
-}
-
-.home-button:hover {
-  background-color: #002244;
-}
 
 .calendly-inline-widget {
   min-width:320px;


### PR DESCRIPTION
## Summary
- create a shared `Common.css`
- add style sheets for About, Events, Credits and Home pages
- remove duplicate styles from Admin and Login CSS
- replace inline styles across pages with CSS classes

## Testing
- `npm run lint`