### PR TITLE
Fix memory leaks in auth listeners

### DIFF
--- a/acm_website/src/components/Navbar.tsx
+++ b/acm_website/src/components/Navbar.tsx
@@ -14,10 +14,11 @@ const Navbar: React.FC<NavbarProps> = ({ navigateTo }) => {
   const [isAdmin, setIsAdmin] = useState(false);
 
   useEffect(() => {
-    onAuthStateChanged(auth, (user) => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
       setIsLoggedIn(!!user);
       setIsAdmin(user?.email === "jhuacmweb@gmail.com");
     });
+    return unsubscribe;
   }, []);
 
   return (

--- a/acm_website/src/pages/AdminPage.tsx
+++ b/acm_website/src/pages/AdminPage.tsx
@@ -54,7 +54,7 @@ const AdminPage: React.FC<AdminPageProps> = ({ navigateTo, error }) => {
   const [attendanceFile, setAttendanceFile] = useState<File | null>(null);
 
   useEffect(() => {
-    onAuthStateChanged(auth, async (user) => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
         // check if user is admin
         if (user.email !== "jhuacmweb@gmail.com") {
@@ -91,6 +91,7 @@ const AdminPage: React.FC<AdminPageProps> = ({ navigateTo, error }) => {
         navigateTo('login', 'Please log in to access the admin page');
       }
     });
+    return unsubscribe;
   }, [navigateTo]);
 
   const handleCreateEvent = async (e: React.FormEvent) => {

--- a/acm_website/src/pages/EventsPage.tsx
+++ b/acm_website/src/pages/EventsPage.tsx
@@ -96,7 +96,7 @@ const EventsPage: React.FC<EventsPageProps> = ({ navigateTo, error }) => {
   }, [db]);
 
   useEffect(() => {
-    onAuthStateChanged(auth, async (user) => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
       setIsLoggedIn(!!user);
       if (user) {
         const userDoc = await getDoc(doc(db, "users", user.uid));
@@ -109,6 +109,7 @@ const EventsPage: React.FC<EventsPageProps> = ({ navigateTo, error }) => {
         }
       } else setRegisteredEvents([]);
     });
+    return unsubscribe;
   }, [db]);
 
   const handleRSVP = async (eventID: string) => {

--- a/acm_website/src/pages/LoginPage.tsx
+++ b/acm_website/src/pages/LoginPage.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect } from 'react';
 import '../styles/LoginPage.css'; // Import the CSS file for styling
 import { auth } from '../firebase/config';
 import { createUserWithEmailAndPassword,
@@ -22,15 +22,18 @@ const LoginPage: React.FC<LoginPageProps> = ({ navigateTo, error }) => {
     setUserCredentials({...userCredentials, [e.target.name]: e.target.value});
   };
 
-  onAuthStateChanged(auth, (user) => {
-    if (user) {
-      if (error?.includes('booking')) {
-        navigateTo('booking');
-      } else {
-        navigateTo('home');
+  useEffect(() => {
+    const unsubscribe = onAuthStateChanged(auth, (user) => {
+      if (user) {
+        if (error?.includes('booking')) {
+          navigateTo('booking');
+        } else {
+          navigateTo('home');
+        }
       }
-    }
-  });
+    });
+    return unsubscribe;
+  }, [navigateTo, error]);
 
   function handleSignup(e: React.FormEvent) {
     e.preventDefault();

--- a/acm_website/src/pages/ProfilePage.tsx
+++ b/acm_website/src/pages/ProfilePage.tsx
@@ -50,7 +50,7 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ navigateTo, error }) => {
   const [currentPassword, setCurrentPassword] = useState<string>('');
 
   useEffect(() => {
-    onAuthStateChanged(auth, async (user) => {
+    const unsubscribe = onAuthStateChanged(auth, async (user) => {
       if (user) {
         setEmail(user.email || '');
         const db = getFirestore();
@@ -100,6 +100,7 @@ const ProfilePage: React.FC<ProfilePageProps> = ({ navigateTo, error }) => {
         navigateTo('login', 'Please log in to access your profile');
       }
     });
+    return unsubscribe;
   }, [navigateTo]);
 
   const handleVerifyPassword = async () => {

--- a/memory-leak-fixes-summary.md
+++ b/memory-leak-fixes-summary.md
@@ -1,0 +1,75 @@
+# Memory Leak Fixes Summary: onAuthStateChanged Listeners
+
+## Overview
+Fixed memory leaks in multiple React components where `onAuthStateChanged` listeners were not properly cleaned up, causing potential memory leaks when components unmount.
+
+## Files Fixed
+
+### 1. **Navbar.tsx** ✅
+- **Issue**: Missing cleanup function for auth state listener
+- **Fix**: Added `const unsubscribe = onAuthStateChanged(...)` and `return unsubscribe;`
+- **Lines**: 16-21
+
+### 2. **EventsPage.tsx** ✅  
+- **Issue**: Missing cleanup function for auth state listener
+- **Fix**: Added `const unsubscribe = onAuthStateChanged(...)` and `return unsubscribe;`
+- **Lines**: 98-113
+
+### 3. **LoginPage.tsx** ✅
+- **Issue**: `onAuthStateChanged` called outside `useEffect` without cleanup
+- **Fix**: 
+  - Added `useEffect` import
+  - Wrapped `onAuthStateChanged` in `useEffect` with proper cleanup
+  - Added dependency array `[navigateTo, error]`
+- **Lines**: 25-35
+
+### 4. **ProfilePage.tsx** ✅
+- **Issue**: Missing cleanup function for auth state listener  
+- **Fix**: Added `const unsubscribe = onAuthStateChanged(...)` and `return unsubscribe;`
+- **Lines**: 52-95
+
+### 5. **AdminPage.tsx** ✅
+- **Issue**: Missing cleanup function for auth state listener
+- **Fix**: Added `const unsubscribe = onAuthStateChanged(...)` and `return unsubscribe;`  
+- **Lines**: 56-89
+
+### 6. **BookingPage.tsx** ✅
+- **Status**: Already correctly implemented
+- **No changes needed** - properly wrapped in `useEffect` with cleanup
+
+## Pattern Applied
+
+### ❌ Before (Problematic):
+```typescript
+useEffect(() => {
+  onAuthStateChanged(auth, (user) => {
+    // handler logic
+  });
+}, []);
+```
+
+### ✅ After (Fixed):
+```typescript
+useEffect(() => {
+  const unsubscribe = onAuthStateChanged(auth, (user) => {
+    // handler logic  
+  });
+  return unsubscribe;
+}, []);
+```
+
+## Benefits of These Fixes
+
+1. **Memory Leak Prevention**: Properly unsubscribing from auth state listeners prevents memory leaks when components unmount
+2. **Performance**: Reduces unnecessary listener callbacks for unmounted components
+3. **React Best Practices**: Follows React's cleanup pattern for subscriptions in useEffect
+4. **Stability**: Prevents potential crashes or unexpected behavior from stale listeners
+
+## Verification
+
+All `onAuthStateChanged` instances in the codebase now follow the correct pattern:
+- Wrapped in `useEffect` 
+- Assigned to `const unsubscribe = onAuthStateChanged(...)`
+- Cleanup function returned: `return unsubscribe;`
+
+The memory leak issues have been completely resolved across all components.


### PR DESCRIPTION
Wrap `onAuthStateChanged` listeners in `useEffect` with cleanup to prevent memory leaks.